### PR TITLE
Internal domains not leaked to external resolver

### DIFF
--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -120,7 +120,7 @@
       the network-provided resolver, will always receive the split-horizon
       results. Conversely, clients that send all queries to a different
       resolver or implement pure full resolution locally will never receive
-      them. Clients that strictly implement either of these resolution behaviors are out of scope for
+      them. Clients with either pure resolution behavior are out of scope for
       this specification. Instead, this specification enables hybrid clients
       to access split-horizon results from a network-provided hybrid resolver,
       while using a different resolution method for some or all other
@@ -174,10 +174,6 @@
       a domain owner to create or authorize a split-horizon view of their
       domain. The protocol does not support split-horizon views created by
       any other entity. Thus, DNS filtering is not enabled by this protocol.</t>
-      <t>The protocol is applicable to any type of network offering
-      split-horizon DNS configuration. The endpoint does not need any prior
-      configuration to confirm that a local domain hint was indeed authorized
-      by the domain.</t>
     </section>
     <section anchor="learning">
       <name>Local Domain Hint Mechanisms</name>
@@ -383,7 +379,7 @@
     "identifier": "pvd.example.com",
     "expires": "2020-05-23T06:00:00Z",
     "prefixes": ["2001:db8:1::/48", "2001:db8:4::/48"],
-    "dnsZones:": ["example.com"]
+    "dnsZones": ["example.com"]
   }]]></artwork>
             <t>The JSON keys "identifier", "expires", and "prefixes"
             are defined in <xref target="RFC8801"/>.</t></li>
@@ -565,10 +561,19 @@
       <t>If an internal zone name (e.g., <tt>internal.example.com</tt>) is used with
       this specification and a public certificate is obtained
       for validation, that internal zone name will exist in Certificate Transparency
-      logs <xref target="RFC9162"/>. It should be
-      noted, however, that this specification does not leak individual host
-      names (e.g., <tt>www.internal.example.com</tt>) into the Certificate Transparency
-      logs or to external DNS resolvers.</t>
+      logs <xref target="RFC9162"/>. In order to not leak the internal domains to
+      an external resolver, the internal domains can be kept in a child zone of the
+      local domain hints advertised by the network. For example, if the PvD "dnsZones"
+      entry is “internal.example.com” and the network-provided DNS resolver is
+      “ns1.internal.example.com”, the network operator can structure the internal
+      domain names as "private1.internal.example.com", "private2.internal.example.com",
+      etc. The network-designated resolver will be used to resolve the subdomains of
+      the local domain hint “*.internal.example.com”. Further, adversaries that monitor
+      a network such as through passive monitoring or active probing of protocols,
+      such as DHCP will only learn the local domain hints but not the internal domains.
+      However, security by obscurity may not maintain or increase the security of the
+      internal domain names, they may be leaked due to various other reasons
+      (e.g., browser reload).</t>
     </section>
     <section anchor="IANA">
       <name>IANA Considerations</name>
@@ -577,7 +582,7 @@
     <section>
       <name>Acknowledgements</name>
       <t>Thanks to Mohamed Boucadair, Jim Reid, Tommy Pauly, Paul Vixie, Paul
-      Wouters and Vinny Parla for the discussion and comments.</t>
+      Wouters, Michael Richardson and Vinny Parla for the discussion and comments.</t>
     </section>
   </middle>
   <!--  *****BACK MATTER ***** -->


### PR DESCRIPTION
This patch addresses the comment to not leak internal domains to an external resolver.