### PR TITLE
Internal domains not leaked to external resolver  via upload

### DIFF
--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -576,7 +576,7 @@
       a network such as through passive monitoring or active probing of protocols,
       such as DHCP will only learn the local domain hints but not the internal domains.
       However, security by obscurity may not maintain or increase the security of the
-      internal domain names, they may be leaked due to various other reasons
+      internal domain names, as they may be leaked in various other ways
       (e.g., browser reload).</t>
     </section>
     <section anchor="IANA">

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -574,7 +574,7 @@
       etc. The network-designated resolver will be used to resolve the subdomains of
       the local domain hint “*.internal.example.com”. Further, adversaries that monitor
       a network such as through passive monitoring or active probing of protocols,
-      such as DHCP will only learn the local domain hints but not the internal domains.
+      such as DHCP will only learn the local domain hints but not learn the labels below internal.example.com.
       However, security by obscurity may not maintain or increase the security of the
       internal domain names, as they may be leaked in various other ways
       (e.g., browser reload).</t>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -383,7 +383,7 @@
     "identifier": "pvd.example.com",
     "expires": "2020-05-23T06:00:00Z",
     "prefixes": ["2001:db8:1::/48", "2001:db8:4::/48"],
-    "dnsZones:": ["example.com"]
+    "dnsZones": ["example.com"]
   }]]></artwork>
             <t>The JSON keys "identifier", "expires", and "prefixes"
             are defined in <xref target="RFC8801"/>.</t></li>
@@ -565,10 +565,19 @@
       <t>If an internal zone name (e.g., <tt>internal.example.com</tt>) is used with
       this specification and a public certificate is obtained
       for validation, that internal zone name will exist in Certificate Transparency
-      logs <xref target="RFC9162"/>. It should be
-      noted, however, that this specification does not leak individual host
-      names (e.g., <tt>www.internal.example.com</tt>) into the Certificate Transparency
-      logs or to external DNS resolvers.</t>
+      logs <xref target="RFC9162"/>. In order to not leak the internal domains to
+      an external resolver, the internal domains can be kept in a child zone of the
+      local domain hints advertised by the network. For example, if the PvD "dnsZones"
+      entry is “internal.example.com” and the network-provided DNS resolver is
+      “ns1.internal.example.com”, the network operator can structure the internal
+      domain names as "private1.internal.example.com", "private2.internal.example.com",
+      etc. The network-designated resolver will be used to resolve the subdomains of
+      the local domain hint “*.internal.example.com”. Further, adversaries that monitor
+      a network such as through passive monitoring or active probing of protocols,
+      such as DHCP will only learn the local domain hints but not the internal domains.
+      However, security by obscurity may not maintain or increase the security of the
+      internal domain names, they may be leaked due to various other reasons
+      (e.g., browser reload).</t>
     </section>
     <section anchor="IANA">
       <name>IANA Considerations</name>
@@ -577,7 +586,7 @@
     <section>
       <name>Acknowledgements</name>
       <t>Thanks to Mohamed Boucadair, Jim Reid, Tommy Pauly, Paul Vixie, Paul
-      Wouters and Vinny Parla for the discussion and comments.</t>
+      Wouters, Michael Richardson and Vinny Parla for the discussion and comments.</t>
     </section>
   </middle>
   <!--  *****BACK MATTER ***** -->


### PR DESCRIPTION
This fix addresses the comment to not leak internal domains to an external resolver.