### PR TITLE
Switch to a prefix-based architecture for validation

### DIFF
--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -140,10 +140,11 @@
       use this protocol to confirm that a local domain hint was authorized by
       the domain (<xref target="validating"/>), which might influence
       its processing of that hint.</t>
-      <t>This specification relies on securely identified local DNS servers
-      and globally valid NS records. Use of this specification is therefore
+      <t>This specification relies on securely identified local DNS servers,
+      and checks each local domain hint against a globally valid parent zone.
+      Use of this specification is therefore
       limited to servers that support authenticated encryption and
-      split-horizon DNS names that are properly rooted in the global DNS.</t>
+      split-horizon DNS names that are rooted in the global DNS.</t>
     </section>
     <section anchor="notation">
       <name>Terminology</name>
@@ -216,7 +217,7 @@
       <ul>
         <li>An Authentication Domain Name (ADN) of a local encrypted resolver.</li>
         <li>The DNS name of the authorizing parent zone.</li>
-        <li>A list of subdomains of this parent zone that are claimed by
+        <li>A set of subdomains of this parent zone that are claimed by
             the named local resolver (potentially including the entire parent
             zone).</li>
         <li>A ZONEMD Hash Algorithm (<relref section="5.3" target="RFC8976"/>).</li>
@@ -232,7 +233,8 @@
       parent zone operator computes a "Verification Token" according to the
       following procedure:</t>
       <ol>
-        <li>Convert all subdomains into canonical form.</li>
+        <li>Convert all subdomains into canonical form and sort them in canonical
+            order (<relref section="6" target="RFC4034"/>).</li>
         <li>Replace the suffix corresponding to the parent zone with a zero
             byte.</li>
         <li>Let $X be the concatenation of the resulting pseudo-FQDNs.</li>
@@ -280,7 +282,8 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
             In DHCP, each Authorization Claim is encoded as a DHCP Authentication
             Option <xref target="RFC3118"/>, using the Protocol value $TBD1, "Split
             DNS Authentication".  The Algorithm field provides the ZONEMD Hash Algorithm,
-            represented by its registered Value.  The Authentication Information
+            represented by its registered Value.  The RDM value
+            <bcp14>MUST</bcp14> be 0x00. The Authentication Information
             <bcp14>MUST</bcp14> contain the following information, concatenated:</t>
           <ol>
             <li>The ADN in canonical form.</li>
@@ -300,8 +303,10 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
             <li>"resolver": The ADN as a dot-separated name.</li>
             <li>"parent": The parent zone name as a dot-separated name.</li>
             <li>"subdomains": An array containing the claimed subdomains, as
-                dot-separated names with the parent suffix already removed.</li>
-            <li>"algorithm": The hash algorithm, identified by its registered Mnemonic.</li>
+                dot-separated names with the parent suffix already removed, in
+                canonical order.</li>
+            <li>"algorithm": The hash algorithm, identified by its IANA-registered
+                Mnemonic.</li>
             <li>"salt": The salt, encoded in base64url.</li>
           </ul>
         </section>
@@ -422,9 +427,7 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
       <section anchor="internal-only">
         <name>Split-Horizon Entire Zone</name>
         <t>Consider an organization that operates "example.com", and runs a
-        different version of its global domain on its internal network. Today,
-        on the Internet it publishes two NS records, "ns1.example.com" and
-        "ns2.example.com".</t>
+        different version of its global domain on its internal network.</t>
         <t>First, the host and network both need to support one of the discovery
         mechanisms described in <xref target="establishing"/>. <xref target="fig-learn"/>
         shows discovery using DNR and PvD.</t>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -219,7 +219,7 @@
         <li>A list of subdomains of this parent zone that are claimed by
             the named local resolver (potentially including the entire parent
             zone).</li>
-        <li>An NSEC3 Hash Algorithm.</li>
+        <li>A ZONEMD Hash Algorithm (<relref section="5.3" target="RFC8976"/>).</li>
         <li>A high-entropy salt, up to 255 octets.</li>
       </ul>
       <t>If the local encrypted resolver is identified by name (e.g., DNR), that
@@ -230,14 +230,14 @@
       <t>To establish its authority, the network MUST provide each Authorization
       Claim to the parent zone operator.  If the contents are approved, the
       parent zone operator computes a "Verification Token" according to the
-      following procedure based on <relref section="5" target="RFC5155"/>:</t>
+      following procedure:</t>
       <ol>
         <li>Convert all subdomains into canonical form.</li>
         <li>Replace the suffix corresponding to the parent zone with a zero
             byte.</li>
         <li>Let $X be the concatenation of the resulting pseudo-FQDNs.</li>
         <li>Let len($SALT) be the number of octets of salt, as a single octet.</li>
-        <li>Let $TOKEN = HASH(len($SALT) || $SALT || $X).</li>
+        <li>Let $TOKEN = hash(len($SALT) || $SALT || $X).</li>
       </ol>
       <t>The zone operator then publishes a "Verification Record" with the
       following structure, following the advice of
@@ -246,7 +246,7 @@
         <li>Type = TXT.</li>
         <li>Owner Name = Concatenation of the ADN, "_splitdns-challenge", and
             the parent zone name.</li>
-        <li>Contents = "token=base64url($TOKEN)".</li>
+        <li>Contents = "token=base64url($TOKEN)" (without padding)</li>
       </ul>
       <t>By publishing this record, the parent zone authorizes the local
       encrypted resolver to serve these subdomains authoritatively.</t>
@@ -258,13 +258,13 @@
           <li>Parent = "parent.example"</li>
           <li>Subdomains = "payroll.parent.example",
               "secret.project.parent.example"</li>
-          <li>Hash Algorithm = SHA-1</li>
+          <li>Hash Algorithm = SHA-384</li>
           <li>Salt = "example salt bytes (should be random)"</li>
         </ul>
         <t>To approve this claim, the zone operator would publish the following record:</t>
         <figure><artwork><![CDATA[
 resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
-"token=kfHudyzZkdQccYVLV0zWsY4ETZUK"
+"token=6rQ7oOZqdg8qQFRqtxpEhK97mNkgFwzNKTmNOtlxspBscZqUwFZZJDDD-Djetw2MCg"
 ]]></artwork></figure>
       </section>
       <section>
@@ -279,7 +279,7 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
           <t>
             In DHCP, each Authorization Claim is encoded as a DHCP Authentication
             Option <xref target="RFC3118"/>, using the Protocol value $TBD1, "Split
-            DNS Authentication".  The Algorithm field provides the NSEC3 Hash Algorithm,
+            DNS Authentication".  The Algorithm field provides the ZONEMD Hash Algorithm,
             represented by its registered Value.  The Authentication Information
             <bcp14>MUST</bcp14> contain the following information, concatenated:</t>
           <ol>
@@ -301,7 +301,7 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
             <li>"parent": The parent zone name as a dot-separated name.</li>
             <li>"subdomains": An array containing the claimed subdomains, as
                 dot-separated names with the parent suffix already removed.</li>
-            <li>"algorithm": The hash algorithm, identified by its Description string.</li>
+            <li>"algorithm": The hash algorithm, identified by its registered Mnemonic.</li>
             <li>"salt": The salt, encoded in base64url.</li>
           </ul>
         </section>
@@ -427,7 +427,7 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
       "resolver": "dns.example.net",
       "parent": "example.com",
       "subdomains": [""],
-      "algorithm": "SHA-1",
+      "algorithm": "SHA384",
       "salt": "abc...123"
     }]
   }]]></artwork>
@@ -645,12 +645,12 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
         <name>Normative References</name>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3118.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5155.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8174.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8801.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6762.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6698.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4035.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8976.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-add-ddr.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-dnsop-domain-verification-techniques.xml"/>
         <reference anchor="IANA-SUDN"

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -264,10 +264,12 @@
           <li>Hash Algorithm = SHA-384</li>
           <li>Salt = "example salt bytes (should be random)"</li>
         </ul>
-        <t>To approve this claim, the zone operator would publish the following record:</t>
+        <t>To approve this claim, the zone operator would publish the following record
+	(using <xref target="RFC8792"/> line-wrapping):</t>
         <sourcecode type="dns-rr">
-resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
-"token=6rQ7oOZqdg8qQFRqtxpEhK97mNkgFwzNKTmNOtlxspBscZqUwFZZJDDD-Djetw2MCg"
+  resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
+  "token=6rQ7oOZqdg8qQFRqtxpEhK97mNkgFwzNKTmNOtlxspBscZqUwFZZJDDD- \
+  Djetw2MCg"
 </sourcecode>
       </section>
       <section>
@@ -724,6 +726,7 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6698.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4035.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8976.xml"/>
+	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8792.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-add-ddr.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-dnsop-domain-verification-techniques.xml"/>
         <reference anchor="IANA-SUDN"

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -220,7 +220,7 @@
             the named local resolver (potentially including the entire parent
             zone).</li>
         <li>An NSEC3 Hash Algorithm.</li>
-        <li>A high-entropy salt.</li>
+        <li>A high-entropy salt, up to 255 octets.</li>
       </ul>
       <t>If the local encrypted resolver is identified by name (e.g., DNR), that
       identifying name MUST be the one used in any corresponding Authorization
@@ -236,7 +236,8 @@
         <li>Replace the suffix corresponding to the parent zone with a zero
             byte.</li>
         <li>Let $X be the concatenation of the resulting pseudo-FQDNs.</li>
-        <li>Let $TOKEN = IH($SALT, $X, 0)</li>
+        <li>Let len($SALT) be the number of octets of salt, as a single octet.</li>
+        <li>Let $TOKEN = HASH(len($SALT) || $SALT || $X).</li>
       </ol>
       <t>The zone operator then publishes a "Verification Record" with the
       following structure, following the advice of
@@ -282,10 +283,10 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
             represented by its registered Value.  The Authentication Information
             <bcp14>MUST</bcp14> contain the following information, concatenated:</t>
           <ol>
-            <li>A one-octet "salt length" field.</li>
-            <li>The salt value.</li>
             <li>The ADN in canonical form.</li>
             <li>The parent name in canonical form.</li>
+            <li>A one-octet "salt length" field.</li>
+            <li>The salt value.</li>
             <li>The $X value defined in <xref target="establishing"/>.</li>
           </ol>
         </section>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -109,7 +109,7 @@
       <t>In many network environments, the network offers clients a DNS server
       (e.g. DHCP OFFER, IPv6 Router Advertisement). Although this server is
       formally specified as a recursive resolver (e.g. <relref section="5.1"
-      target="RFC6106"/>), some networks provide a hybrid resolver
+      target="RFC8106"/>), some networks provide a hybrid resolver
       instead. If this resolver acts as an authoritative server for some
       names, we say that the network has "split-horizon DNS", because those
       names resolve in this way only from inside the network.</t>
@@ -726,7 +726,6 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6698.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4035.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8976.xml"/>
-	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8792.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-add-ddr.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-dnsop-domain-verification-techniques.xml"/>
         <reference anchor="IANA-SUDN"
@@ -747,12 +746,13 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8598.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7686.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8806.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6106.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8106.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4702.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4704.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6731.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5986.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8310.xml"/>
+	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8792.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-add-dnr.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-ipsecme-add-ike.xml"/>
     </references>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -676,6 +676,7 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
         <name>Normative References</name>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3118.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4034.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8174.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8801.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6762.xml"/>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -264,10 +264,10 @@
           <li>Salt = "example salt bytes (should be random)"</li>
         </ul>
         <t>To approve this claim, the zone operator would publish the following record:</t>
-        <figure><artwork><![CDATA[
+        <sourcecode type="dns-rr">
 resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
 "token=6rQ7oOZqdg8qQFRqtxpEhK97mNkgFwzNKTmNOtlxspBscZqUwFZZJDDD-Djetw2MCg"
-]]></artwork></figure>
+</sourcecode>
       </section>
       <section>
         <name>Conveying Authorization Claims</name>
@@ -390,7 +390,7 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
       when resolving the claimed subdomains via this local encrypted resolver.</t>
       <figure>
         <name>Example use of "ds=..."</name>
-        <artwork><![CDATA[
+        <sourcecode>
 ;; Parent zone
 $ORIGIN parent.example.
 
@@ -415,7 +415,7 @@ resolver.arpa. IN DNSKEY 257 3 5 ASDF...=
 subdomain.parent.example.        IN DNSKEY 256 3 5 FDSA...=
 subdomain.parent.example.        IN AAAA 2001:db8::17
 deeper.subdomain.parent.example. IN AAAA 2001:db8::18
-]]></artwork></figure>
+</sourcecode></figure>
     </section>
 
     <section>
@@ -451,18 +451,18 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
             validates its certificate, and retrieves the provisioning domain
             JSON information indicated by the associated PvD. The PvD
             contains:</t>
-            <artwork><![CDATA[  {
-    "identifier": "pvd.example.com",
-    "expires": "2020-05-23T06:00:00Z",
-    "prefixes": ["2001:db8:1::/48", "2001:db8:4::/48"],
-    "$TBD2": [{
-      "resolver": "dns.example.net",
-      "parent": "example.com",
-      "subdomains": [""],
-      "algorithm": "SHA384",
-      "salt": "abc...123"
-    }]
-  }]]></artwork>
+            <sourcecode type="json">{
+  "identifier": "pvd.example.com",
+  "expires": "2020-05-23T06:00:00Z",
+  "prefixes": ["2001:db8:1::/48", "2001:db8:4::/48"],
+  "$TBD2": [{
+    "resolver": "dns.example.net",
+    "parent": "example.com",
+    "subdomains": [""],
+    "algorithm": "SHA384",
+    "salt": "abc...123"
+  }]
+}</sourcecode>
             <t>The JSON keys "identifier", "expires", and "prefixes"
             are defined in <xref target="RFC8801"/>.</t></li>
         </ul>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -210,7 +210,7 @@
       <t>To establish its authority over some DNS zone, a
       participating network <bcp14>MUST</bcp14> offer one or more
       encrypted resolvers via DNR <xref target="I-D.ietf-add-dnr"/>,
-      DDR <xref target="I-D.ietf-add-dnr"/>, or an equivalent mechanism
+      DDR <xref target="I-D.ietf-add-ddr"/>, or an equivalent mechanism
       (see <xref target="vpn"/>).</t>
       <t>To establish local authority, the network MUST convey one or more
       "Authorization Claims" to the client.  An "Authorization Claim" is an

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -295,8 +295,9 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
         </section>
         <section>
           <name>Using Provisioning Domains</name>
-          <t>When using Provisioning Domains, the Authorization Claims are represented
-          by the PvD Additional Information key $TBD2, whose value is a
+          <t>When using <xref target="RFC8801">Provisioning Domains</xref>, the
+          Authorization Claims are represented by the PvD Additional
+          Information key "splitDnsClaims", whose value is a
           JSON Array.  Each entry in the array <bcp14>MUST</bcp14> be a JSON object
           with the following structure:</t>
           <ul>
@@ -659,7 +660,46 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
     </section>
     <section anchor="IANA">
       <name>IANA Considerations</name>
-      <t>TODO: New DHCP Auth Algorithm, PvD key, and underscore registry name.</t>
+      <section>
+        <name>DHCP Split DNS Authentication Algorithm</name>
+        <t>IANA is requested to add the following entry to the "Protocol Name Space
+        Values" registry on the "Dynamic Host Configuration Protocol (DHCP)
+        Authentication Option Name Spaces" page:</t>
+        <ul>
+          <li>Value: $TBD1</li>
+          <li>Description: Split DNS</li>
+          <li>Reference: (This Document)</li>
+        </ul>
+      </section>
+      <section>
+        <name>Provisioning Domains Split DNS Additional Information</name>
+        <t>IANA is requested to add the following entry to the "Additional
+        Information PvD Keys" registry on the "Provisioning Domains (PvDs)" page:</t>
+        <ul>
+          <li>JSON key: "splitDnsClaims"</li>
+          <li>Description: "Verifiable locally served domains"</li>
+          <li>Type: Array of Objects</li>
+          <li><t>Example: </t><sourcecode type="json">[{
+  "resolver": "dns.example.net",
+  "parent": "example.com",
+  "subdomains": ["sub"],
+  "algorithm": "SHA384",
+  "salt": "abc...123"
+}]</sourcecode></li>
+          <li>Reference: (This document)</li>
+        </ul>
+      </section>
+      <section>
+        <name>DNS Underscore Name</name>
+        <t>IANA is requested to add the following entry to the "Underscored and
+        Globally Scoped DNS Node Names" registry on the "Domain Name System (DNS)
+        Parameters" page:</t>
+        <ul>
+          <li>RR Type: TXT</li>
+          <li>_NODE NAME: _splitdns-challenge</li>
+          <li>Reference: (This document)</li>
+        </ul>
+      </section>
     </section>
     <section>
       <name>Acknowledgements</name>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -372,11 +372,11 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
       Name is "resolver.arpa."</t>
       <t>To validate DNSSEC, the client first fetches and validates the Verification
       Record.  If it is valid and contains a "ds" key, the client <bcp14>MAY</bcp14>
-      send a DNSKEY query for "resolver.arpa." to the local encrypted resolver.  At
-      least one resulting DNSKEY RR <bcp14>MUST</bcp14> match the DS RDATA from the
-      Verification Record. All local resolution results for subdomains in this
-      claim <bcp14>MUST</bcp14> offer RRSIGs that chain to one of these approved
-      DNSKEYs.</t>
+      send a DNSKEY query for "resolver.arpa." to the local encrypted resolver.
+      At least one resulting DNSKEY RR <bcp14>MUST</bcp14> match the DS RDATA from
+      the "ds" key in the Verification Record. All local resolution results for
+      subdomains in this claim <bcp14>MUST</bcp14> offer RRSIGs that chain to one
+      of these approved DNSKEYs.</t>
       <t>The "ds" key <bcp14>MAY</bcp14> appear multiple
       times in a single Verification Record, in order to authorize multiple DNSKEYs
       for this local encrypted resolver.  If the "ds" key is not present in a valid

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -315,7 +315,7 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
       Claim, the client <bcp14>SHALL</bcp14> regard the named resolver as
       authoritative for the claimed subdomains. Clients <bcp14>MUST</bcp14> ignore
       any unrecognized keys in the Verification Record.</t>
-      <t>Each validation of authority applies only to a specific Authorization
+      <t>Each validation of authority applies only to a specific Authentication
       Domain Name. If a network offers multiple encrypted resolvers, each claimed
       subdomain may be authorized for a distinct subset of the network-provided
       resolvers.</t>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -382,6 +382,34 @@ resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
       for this local encrypted resolver.  If the "ds" key is not present in a valid
       Verification Record, the client <bcp14>MUST</bcp14> disable DNSSEC validation
       when resolving the claimed subdomains via this local encrypted resolver.</t>
+      <figure>
+        <name>Example use of "ds=..."</name>
+        <artwork><![CDATA[
+;; Parent zone
+$ORIGIN parent.example.
+
+; Parent zone's public KSK and ZSK
+@ IN DNSKEY 257 3 5 ABCD...=
+@ IN DNSKEY 256 3 5 DCBA...=
+
+; Verification Record containing DS RDATA for the local
+; resolver's KSK.  This is an ordinary public TXT record,
+; secured by RRSIGs from the public ZSK.
+resolver.example._splitdns-challenge IN TXT "token=abc...,ds=QWE..."
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Local zone, claiming "subdomain.parent.example".
+
+; The local resolver's KSK, validated by the Verification Record.
+resolver.arpa. IN DNSKEY 257 3 5 ASDF...=
+
+; Each claimed subdomain has its own ZSK, which is signed by the
+; KSK and is used to sign records at that subdomain and below.
+subdomain.parent.example.        IN DNSKEY 256 3 5 FDSA...=
+subdomain.parent.example.        IN AAAA 2001:db8::17
+deeper.subdomain.parent.example. IN AAAA 2001:db8::18
+]]></artwork></figure>
     </section>
 
     <section>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -742,17 +742,12 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8499.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9162.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8598.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7556.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7686.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8806.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6106.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3646.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3397.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4702.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4704.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6731.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2937.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2132.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5986.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8310.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-add-dnr.xml"/>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -456,7 +456,7 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
   "identifier": "pvd.example.com",
   "expires": "2020-05-23T06:00:00Z",
   "prefixes": ["2001:db8:1::/48", "2001:db8:4::/48"],
-  "$TBD2": [{
+  "splitDnsClaims": [{
     "resolver": "dns.example.net",
     "parent": "example.com",
     "subdomains": [""],
@@ -491,7 +491,7 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
    |------------------------------------>|         |            |
    | ---------------------------\        |         |            |
    |-| validate TLS certificate |        |         |            |
-   | |--------------------------|        |         |            |
+   | |--------------------------/        |         |            |
    |                                     |         |            |
    | resolve pvd.example.com  (4)        |         |            |
    |------------------------------------>|         |            |
@@ -504,9 +504,9 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
    |                                     |         |            |
    |  200 OK (JSON Additional Information) (7)     |            |
    |<----------------------------------------------|            |
-   | -------------------------\          |         |            |
-   |-| {..., "$TBD2": [...] } |          |         |            |
-   | |------------------------|          |         |            |
+   | ----------------------------------\ |         |            |
+   |-| {..., "splitDnsClaims": [...] } | |         |            |
+   | |---------------------------------/ |         |            |
 ]]></artwork>
         </figure>
         <section anchor="example-verify-external">

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -75,8 +75,9 @@
       <t>When split-horizon DNS is deployed by a network, certain domains can
       be resolved authoritatively by the network-provided DNS resolver. DNS
       clients that don't always use this resolver might wish to do so for
-      these domains. This specification describes how clients can confirm the
-      local resolver's authority over these domains.</t>
+      these domains. This specification defines a mechanism for domain owners
+      to inform clients about local resolvers that are authorized to answer
+      authoritatively for certain subdomains.</t>
     </abstract>
     <note title="Discussion Venues" removeInRFC="true">
       <t>Discussion of this document takes place on the
@@ -123,7 +124,12 @@
       names.</t>
       <t>There are several existing mechanisms for a network to provide
       clients with "local domain hints", listing domain names that have
-      special treatment in this network (<xref target="learning"/>).
+      special treatment in this network (e.g., <xref target="RFC6731">
+      RDNSS Selection</xref>, <xref target="RFC5986">
+      "Access Network Domain Name"</xref>, and "Client FQDN" <xref
+      target="RFC4702"/><xref target="RFC4704"/> in DHCP, "dnsZones" in
+      Provisioning Domains <xref target="RFC8801"/>, and <xref
+      target="RFC8598">INTERNAL_DNS_DOMAIN</xref> in IKEv2).
       However, none of the local domain hint mechanisms enable clients to
       determine whether this special treatment is authorized by the domain
       owner. Instead, these specifications require clients to make their own
@@ -179,136 +185,141 @@
       unique to a specific DNS server's authority. All special-use domain names are outside the
       scope of this document and MUST NOT be validated using the mechanism described in this document. </t>
     </section>
-    <section anchor="learning">
-      <name>Local Domain Hint Mechanisms</name>
-      <t>There are various mechanisms by which a network client might learn
-      "local domain hints", which indicate a special treatment for particular
-      domain names upon joining a network. This section provides a review of
-      some common and standardized mechanisms for receiving domain hints.</t>
-      <section anchor="dhcp">
-        <name>DHCP Options</name>
-        <t>There are several DHCP options that convey local domain hints of
-        different kinds. The most directly relevant is <xref target="RFC6731">
-        RDNSS Selection</xref>, which provides "a list of domains ... about
-        which the RDNSS has special knowledge", along with a "High", "Medium",
-        or "Low" preference for each name. The specification notes the
-        difficulty of relying on these hints without validation:</t>
-        <blockquote>
-          <t>Trustworthiness of an interface and configuration information
-            received over the interface is implementation and/or node
-            deployment dependent, and the details of determining that trust
-            are beyond the scope of this specification.</t>
-        </blockquote>
-        <t>Other local domain hints in DHCP include the <xref
-        target="RFC2132">"Domain Name"</xref>, <xref target="RFC5986">
-        "Access Network Domain Name"</xref>, "Client FQDN" <xref
-        target="RFC4702"/><xref target="RFC4704"/>, and <xref target="RFC2937">
-        "Name Service Search"</xref> options. This
-        specification may help clients to interpret these hints. For example,
-        a rogue DHCP server could use the "Client FQDN" option to assign a
-        client the name "www.example.com" in order to prevent the client from
-        reaching the true "www.example.com". A client could use this
-        specification to check the network's authority over this name, and
-        adjust its behavior to avoid this attack if authority is not
-        established.</t>
-        <t>The Domain Search option <xref target="RFC3397"/><xref
-        target="RFC3646"/>, which offers clients a way to expand short
-        names into Fully Qualified Domain Names, is not a "local domain hint"
-        by this definition, because it does not modify the processing of any
-        specific domain. (The specification notes that this option can be a
-        "fruitful avenue of attack for a rogue DHCP server", and provides a
-        number of cautions against accepting it unconditionally.)</t>
-      </section>
-      <section anchor="hostconfig">
-        <name>Host Configuration</name>
-        <t>A host can be configured with DNS information when it joins a
-        network, including when it brings up VPN (which is also considered
-        joining a(n additional) network, detailed in <xref
-        target="vpn"/>). Existing implementations determine the host has
-        joined a certain network via SSID, IP subnet assigned, DNS server IP
-        address or name, and other similar mechanisms. For example, one
-        existing implementation determines the host has joined an internal
-        network because the DHCP-assigned IP address belongs to the company's
-        IP range (as assigned by the regional IP addressing authority) and
-        the DHCP-advertised DNS IP address is one used by IT at that network.
-        Other mechanisms exist in other products but are not interesting to
-        this specification; rather what is interesting is this step to
-        determine "we have joined the internal corporate network" occurred and
-        the DNS server is configured as authoritative for certain DNS zones
-        (e.g., <tt>*.example.com</tt>).</t>
-        <t>Because a rogue network can simulate all or most of the above
-        characteristics, this specification details how to validate these
-        claims in <xref target="validating"/>.</t>
-      </section>
-      <section anchor="dnsZones">
-        <name>Provisioning Domains dnsZones</name>
-        <t>Provisioning Domains (PvDs) are defined in <xref
-        target="RFC7556"/> as sets of network configuration information
-        that clients can use to access networks, including rules for DNS
-        resolution and proxy configuration. The PvD Key "dnsZones" is defined
-        in <xref target="RFC8801"/> as a list of "DNS zones searchable
-        and accessible" in this provisioning domain. Attempting to resolve
-        these names via another resolver might fail or return results that are
-        not correct for this network.</t>
-      </section>
-      <!-- provisioning domains -->
-
-      <section>
-        <name>Split DNS Configuration for IKEv2</name>
-        <t>In IKEv2 VPNs, the INTERNAL_DNS_DOMAIN configuration attribute can
-        be used to indicate that a domain is "internal" to the VPN <xref
-        target="RFC8598"/>. To prevent abuse, the specification notes
-        various possible restrictions on the use of this attribute: </t>
-        <blockquote>
-          <t>If a client is configured by local policy to only accept a
-            limited set of INTERNAL_DNS_DOMAIN values, the client MUST ignore
-            any other INTERNAL_DNS_DOMAIN values.
-            (<relref section="5" target="RFC8598" displayFormat="comma"/>)</t>
-          <t>IKE clients MAY want to require whitelisted domains for
-            Top-Level Domains (TLDs) and Second-Level Domains (SLDs) to
-            further prevent malicious DNS redirections for well-known
-            domains.
-            (<relref section="9" target="RFC8598" displayFormat="comma"/>)</t>
-        </blockquote>
-        <t> Within these guidelines, a client could adopt a local policy
-        of accepting INTERNAL_DNS_DOMAIN values only when it can validate the
-        local DNS server's authority over those names as described in this
-        specification.</t>
-      </section>
+    <section>
+      <name>Requirements</name>
+      <t>This solution seeks to fulfill the following requirements:</t>
+      <ul>
+        <li>No loss of security: No unauthorized party can impersonate
+          a zone unless they could already do so without use of this
+          specification.</li>
+        <li>Least privilege: Local resolvers do not hold any
+          secrets that could weaken the security of the public zone if
+          compromised.</li>
+        <li>Local zone confidentiality: The specification does not leak
+          local network subdomains to anyone outside of the network.</li>
+        <li>Flexibility: The specification can represent and authorize
+          any reasonable Split DNS zone structure.</li>
+        <li>DNSSEC Compatibility: The specification supports DNSSEC-based
+          object security for local zone contents.</li>
+      </ul>
     </section>
-    <!-- Learning -->
-
     <section anchor="establishing">
       <name>Establishing Local DNS Authority</name>
       <t>To establish its authority over some DNS zone, a
       participating network <bcp14>MUST</bcp14> offer one or more
       encrypted resolvers via DNR <xref target="I-D.ietf-add-dnr"/>,
       DDR <xref target="I-D.ietf-add-dnr"/>, or an equivalent mechanism
-      (see <xref target="vpn"/>).  If the encrypted resolver is
-      identified by name (e.g., DNR), at least one of these resolvers'
-      Authentication Domain Names (ADNs) <bcp14>MUST</bcp14> appear in
-      an NS record for that zone.  If the encrypted resolver is
-      identified by IP address (e.g., DDR), then the resolver MUST present a
-      certificate that can be validated by the client, containing at least
-      one subjectAltName entry that matches an NS record for that zone.
-      This arrangement establishes this resolver's authority over the zone.</t>
+      (see <xref target="vpn"/>).</t>
+      <t>To establish local authority, the network MUST convey one or more
+      "Authorization Claims" to the client.  An "Authorization Claim" is an
+      abstract structure comprising:</t>
+      <ul>
+        <li>An Authentication Domain Name (ADN) of a local encrypted resolver.</li>
+        <li>The DNS name of the authorizing parent zone.</li>
+        <li>A list of subdomains of this parent zone that are claimed by
+            the named local resolver (potentially including the entire parent
+            zone).</li>
+        <li>An NSEC3 Hash Algorithm.</li>
+        <li>A high-entropy salt.</li>
+      </ul>
+      <t>If the local encrypted resolver is identified by name (e.g., DNR), that
+      identifying name MUST be the one used in any corresponding Authorization
+      Claim.  Otherwise (e.g., DDR using IP addresses), the resolver MUST
+      present a validatable certificate containing a subjectAltName that
+      matches the Authorization Claim.</t>
+      <t>To establish its authority, the network MUST provide each Authorization
+      Claim to the parent zone operator.  If the contents are approved, the
+      parent zone operator computes a "Verification Token" according to the
+      following procedure based on <relref section="5" target="RFC5155"/>:</t>
+      <ol>
+        <li>Convert all subdomains into canonical form.</li>
+        <li>Replace the suffix corresponding to the parent zone with a zero
+            byte.</li>
+        <li>Let $X be the concatenation of the resulting pseudo-FQDNs.</li>
+        <li>Let $TOKEN = IH($SALT, $X, 0)</li>
+      </ol>
+      <t>The zone operator then publishes a "Verification Record" with the
+      following structure, following the advice of
+      <xref target="I-D.ietf-dnsop-domain-verification-techniques"/>:</t>
+      <ul>
+        <li>Type = TXT.</li>
+        <li>Owner Name = Concatenation of the ADN, "_splitdns-challenge", and
+            the parent zone name.</li>
+        <li>Contents = "token=base64url($TOKEN)".</li>
+      </ul>
+      <t>By publishing this record, the parent zone authorizes the local
+      encrypted resolver to serve these subdomains authoritatively.</t>
+      <section>
+        <name>Example</name>
+        <t>Consider the following authorization claim:</t>
+        <ul>
+          <li>ADN = "resolver17.parent.example"</li>
+          <li>Parent = "parent.example"</li>
+          <li>Subdomains = "payroll.parent.example",
+              "secret.project.parent.example"</li>
+          <li>Hash Algorithm = SHA-1</li>
+          <li>Salt = "example salt bytes (should be random)"</li>
+        </ul>
+        <t>To approve this claim, the zone operator would publish the following record:</t>
+        <figure><artwork><![CDATA[
+resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
+"token=kfHudyzZkdQccYVLV0zWsY4ETZUK"
+]]></artwork></figure>
+      </section>
+      <section>
+        <name>Conveying Authorization Claims</name>
+        <t>
+          The Authorization Claim is an abstract structure that must be encoded in
+          some concrete syntax in order to convey it from the network to the client.
+          This section defines some encodings of the Authorization Claims.
+        </t>
+        <section>
+          <name>Using DHCP</name>
+          <t>
+            In DHCP, each Authorization Claim is encoded as a DHCP Authentication
+            Option <xref target="RFC3118"/>, using the Protocol value $TBD1, "Split
+            DNS Authentication".  The Algorithm field provides the NSEC3 Hash Algorithm,
+            represented by its registered Value.  The Authentication Information
+            <bcp14>MUST</bcp14> contain the following information, concatenated:</t>
+          <ol>
+            <li>A one-octet "salt length" field.</li>
+            <li>The salt value.</li>
+            <li>The ADN in canonical form.</li>
+            <li>The parent name in canonical form.</li>
+            <li>The $X value defined in <xref target="establishing"/>.</li>
+          </ol>
+        </section>
+        <section>
+          <name>Using Provisioning Domains</name>
+          <t>When using Provisioning Domains, the Authorization Claims are represented
+          by the PvD Additional Information key $TBD2, whose value is a
+          JSON Array.  Each entry in the array <bcp14>MUST</bcp14> be a JSON object
+          with the following structure:</t>
+          <ul>
+            <li>"resolver": The ADN as a dot-separated name.</li>
+            <li>"parent": The parent zone name as a dot-separated name.</li>
+            <li>"subdomains": An array containing the claimed subdomains, as
+                dot-separated names with the parent suffix already removed.</li>
+            <li>"algorithm": The hash algorithm, identified by its Description string.</li>
+            <li>"salt": The salt, encoded in base64url.</li>
+          </ul>
+        </section>
+      </section>
     </section>
     <section anchor="validating">
       <name>Validating Authority over Local Domain Hints</name>
-      <t>To validate the network's authority over a domain name, participating
-      clients <bcp14>MUST</bcp14> resolve the NS record for that name. If the resolution
-      result is NODATA, the client <bcp14>MUST</bcp14> remove the last label and repeat the
-      query until a response other than NODATA is received.</t>
-      <t>Once the NS record has been resolved, the client <bcp14>MUST</bcp14> check if each
-      local encrypted resolver's Authentication Domain Name appears in the NS
-      record. The client <bcp14>SHALL</bcp14> regard each such resolver as authoritative for
-      the zone of this NS record.</t>
-      <t>Each validation of authority applies only to the specific resolvers
-      whose names appear in the NS RRSet. If a network offers multiple
-      encrypted resolvers, each DNS entry may be authorized for a distinct
-      subset of the network-provided resolvers.</t>
+      <t>To validate an Authorization Claim provided by the network, participating
+      clients <bcp14>MUST</bcp14> resolve the Verification Record for that name.
+      If the resolution produces an RRSet containing the expected token for this
+      Claim, the client <bcp14>SHALL</bcp14> regard the named resolver as
+      authoritative for the claimed subdomains. Clients <bcp14>MUST</bcp14> ignore
+      any unrecognized keys in the Verification Record.</t>
+      <t>Each validation of authority applies only to a specific Authorization
+      Domain Name. If a network offers multiple encrypted resolvers, each claimed
+      subdomain may be authorized for a distinct subset of the network-provided
+      resolvers.</t>
       <t>A zone is termed a "Validated Split-Horizon zone" after successful
-      validation using a "tamperproof" NS resolution method, i.e. a method
+      validation using a "tamperproof" DNS resolution method, i.e. a method
       that is not subject to interference by the local network operator. Two
       possible tamperproof resolution methods are presented below.</t>
       <section anchor="validating-external">
@@ -316,21 +327,21 @@
         <t>This method applies only if the client is already configured with
         a default resolution strategy that sends queries to a resolver outside
         of the network over a secure transport.  That resolution strategy is
-        considered "tamperproof" because any actor who could modify the NS
+        considered "tamperproof" because any actor who could modify the
         response could already modify all of the user's other DNS responses.</t>
         <t>To ensure that this assumption holds, clients <bcp14>MUST NOT</bcp14>
         relax the acceptance rules they would otherwise apply when using this
         resolver. For example, if the client would check the AD bit or
         validate RRSIGs locally when using this resolver, it must also do so
-        when resolving NS records for this purpose. Alternatively, a client might
-        perform DNSSEC validation for the NS query used for this purpose
+        when resolving TXT records for this purpose. Alternatively, a client might
+        perform DNSSEC validation for the verification query
         even if it has disabled DNSSEC validation for other DNS queries.</t>
       </section>
       <!-- validating-external -->
 
       <section anchor="validating-dnssec">
         <name>Using DNSSEC</name>
-        <t>The client resolves the NS record using any resolution method of
+        <t>The client resolves the Verification Record using any resolution method of
         its choice (e.g. querying one of the network-provided resolvers,
         performing iterative resolution locally), and performs full DNSSEC
         validation locally <xref target="RFC6698"/>. The result is
@@ -351,6 +362,28 @@
     <!-- Validating -->
 
     <section>
+      <name>Delegating DNSSEC across Split DNS Boundaries</name>
+      <t>We wish to enable DNSSEC validation of local DNS names without requiring
+      the local resolver to hold DNSSEC private keys that are valid for the parent
+      zone.  To support this configuration, parent zones <bcp14>MAY</bcp14> add a
+      "ds=..." key to the Verification Record whose value is the RDATA of a single
+      DS record, base64url-encoded. This DS record authorizes a DNSKEY whose Owner
+      Name is "resolver.arpa."</t>
+      <t>To validate DNSSEC, the client first fetches and validates the Verification
+      Record.  If it is valid and contains a "ds" key, the client <bcp14>MAY</bcp14>
+      send a DNSKEY query for "resolver.arpa." to the local encrypted resolver.  At
+      least one resulting DNSKEY RR <bcp14>MUST</bcp14> match the DS RDATA from the
+      Verification Record. All local resolution results for subdomains in this
+      claim <bcp14>MUST</bcp14> offer RRSIGs that chain to one of these approved
+      DNSKEYs.</t>
+      <t>The "ds" key <bcp14>MAY</bcp14> appear multiple
+      times in a single Verification Record, in order to authorize multiple DNSKEYs
+      for this local encrypted resolver.  If the "ds" key is not present in a valid
+      Verification Record, the client <bcp14>MUST</bcp14> disable DNSSEC validation
+      when resolving the claimed subdomains via this local encrypted resolver.</t>
+    </section>
+
+    <section>
       <name>Examples of Split-Horizon DNS Configuration</name>
       <t>Two examples are shown below. The first example shows a company
       with an internal-only DNS server that claims the entire zone for that
@@ -364,18 +397,18 @@
         on the Internet it publishes two NS records, "ns1.example.com" and
         "ns2.example.com".</t>
         <t>First, the host and network both need to support one of the discovery
-        mechanisms described in <xref target="learning"/>. <xref target="fig-learn"/>
+        mechanisms described in <xref target="establishing"/>. <xref target="fig-learn"/>
         shows discovery using DNR and PvD.</t>
         <t>Validation is then perfomed using either <xref
         target="example-verify-external">an external resolver</xref> or <xref
         target="example-verify-dnssec">DNSSEC</xref>.</t>
         <ul empty="true">
           <li><strong>Steps 1-2</strong>: The client determines the network's DNS
-            server (ns1.example.com) and Provisioning Domain (pvd.example.com)
+            server (dns.example.net) and Provisioning Domain (pvd.example.com)
             using <xref target="I-D.ietf-add-dnr">DNR</xref> and <xref
             target="RFC8801">PvD</xref>, using one of DNR Router Solicitation,
             DHCPv4, or DHCPv6.</li>
-          <li><strong>Step 3-5</strong>: The client connects to ns1.example.com
+          <li><strong>Step 3-5</strong>: The client connects to dns.example.net
             using an encrypted transport as indicated in <xref
             target="I-D.ietf-add-dnr">DNR</xref>, authenticating the server to
             its name using TLS (<relref target="RFC8310" section="8"
@@ -389,7 +422,13 @@
     "identifier": "pvd.example.com",
     "expires": "2020-05-23T06:00:00Z",
     "prefixes": ["2001:db8:1::/48", "2001:db8:4::/48"],
-    "dnsZones": ["example.com"]
+    "$TBD2": [{
+      "resolver": "dns.example.net",
+      "parent": "example.com",
+      "subdomains": [""],
+      "algorithm": "SHA-1",
+      "salt": "abc...123"
+    }]
   }]]></artwork>
             <t>The JSON keys "identifier", "expires", and "prefixes"
             are defined in <xref target="RFC8801"/>.</t></li>
@@ -414,7 +453,7 @@
    | | PvD FQDN                  |       |         |            |
    | |---------------------------/       |         |            |
    |                                     |         |            |
-   | TLS connection to ns1.example.com (3)         |            |
+   | TLS connection to dns.example.net (3)         |            |
    |------------------------------------>|         |            |
    | ---------------------------\        |         |            |
    |-| validate TLS certificate |        |         |            |
@@ -431,9 +470,9 @@
    |                                     |         |            |
    |  200 OK (JSON Additional Information) (7)     |            |
    |<----------------------------------------------|            |
-   | -----------------------\            |         |            |
-   |-| dnsZones=example.com |            |         |            |
-   | |----------------------|            |         |            |
+   | -------------------------\          |         |            |
+   |-| {..., "$TBD2": [...] } |          |         |            |
+   | |------------------------|          |         |            |
 ]]></artwork>
         </figure>
         <section anchor="example-verify-external">
@@ -442,19 +481,17 @@
           claims of DNS authority using an external resolver.</t>
           <ul empty="true">
             <li><strong>Steps 1-2</strong>: The client uses an encrypted DNS
-              connection to an external resolver (e.g., 1.1.1.1) to issue NS
-              queries for the domains in dnsZones. The NS lookup for
-              "example.com" will return "ns1.example.com" and
-              "ns2.example.com".</li>
-            <li><strong>Step 3</strong>: The network-provided DNS servers are
-              listed in the NS record for <tt>example.com</tt>, which was
-              retrieved from an external resolver over a secure transport,
-              so these ADNs are authorized. When the client connects using an
+              connection to an external resolver (e.g., 1.1.1.1) to issue TXT
+              queries for the Verification Records. The TXT lookup returns
+              a token that matches the claim.</li>
+            <li><strong>Step 3</strong>: The client has validated that
+              <tt>example.com</tt> has authorized <tt>dns.example.net</tt>
+              to serve <tt>example.com</tt>. When the client connects using an
               encrypted transport as indicated in <xref
               target="I-D.ietf-add-dnr">DNR</xref>, it will authenticate
               the server to its name using TLS (<relref target="RFC8310"
               section="8" displayFormat="comma"/>), and send queries to resolve
-              any names that fall within the dnsZones from PvD.</li>
+              any names that fall within the claimed zones.</li>
           </ul>
           <figure>
             <name>Verifying claims using an external resolver</name>
@@ -470,19 +507,20 @@
      |-| validate TLS certificate |             |         |
      | |--------------------------|             |         |
      |                                          |         |
-     | NS? example.com  (1)                     |         |
+     | TXT? dns.example.net.\                   |         |
+     |   _splitdns-challenge.example.com  (1)   |         |
      |--------------------------------------------------->|
      |                                          |         |
-     |  NS=ns1.example.com, ns2.example.com (2) |         |
+     |  TXT "token=ABC..."                  (2) |         |
      |<---------------------------------------------------|
-     | -------------------------------\         |         |
-     |-| both DNR ADNs are authorized |         |         |
-     | ----------------------\--------|         |         |
+     | --------------------------------\        |         |
+     |-| dns.example.net is authorized |        |         |
+     | ----------------------\---------|        |         |
      |-| finished validation |                  |         |
      | |---------------------|                  |         |
      |                                          |         |
-     |  use network-designated resolver         |         |
-     |  for example.com (3)                     |         |
+     |  use dns.example.net when                |         |
+     |  resolving example.com (3)               |         |
      |----------------------------------------->|         |
      |                                          |         |
 ]]></artwork>
@@ -496,19 +534,17 @@
           claims of DNS authority using DNSSEC.</t>
           <ul empty="true">
             <li><strong>Steps 1-2</strong>: The DNSSEC-validating client queries
-              the network encrypted resolver to issue NS queries for the
-              domains in dnsZones. The NS lookup for "example.com" will return
-              a signed response containing "ns1.example.com" and
-              "ns2.example.com". The client then performs full DNSSEC
-              validation locally.</li>
+              the network encrypted resolver to issue TXT queries for the
+              Verification Records. The TXT lookup will return
+              a signed response containing the expected token. The client then
+              performs full DNSSEC validation locally.</li>
             <li><strong>Step 3</strong>: The DNSSEC validation is successful and
-              the network-provided DNS servers are listed in the signed NS
-              record for <tt>example.com</tt>, so these ADNs are authorized.
+              the token matches, so this Authorization Claim is validated.
               When the client connects using an encrypted transport as indicated
               in <xref target="I-D.ietf-add-dnr">DNR</xref>, it will authenticate
               the server to its name using TLS (<relref target="RFC8310"
               section="8" displayFormat="comma"/>), and send queries to resolve
-              any names that fall within the dnsZones from PvD.</li>
+              any names that fall within the claimed zones.</li>
           </ul>
           <figure>
             <name>Verifying claims using DNSSEC</name>
@@ -518,17 +554,18 @@
 |         |                                    | Encrypted Resolver |
 +---------+                                    +--------------------+
   |                                                               |
-  | DNSSEC OK (DO), NS? example.com  (1)                          |
+  | DNSSEC OK (DO), TXT? dns.example.net.\                        |
+  |   _splitdns-challenge.example.com  (1)                        |
   |-------------------------------------------------------------->|
   |                                                               |
-  | NS=ns1.example.com,ns2.example.com, Signed Answer (RRSIG) (2) |
+  | TXT token=DEF..., Signed Answer (RRSIG) (2)                   |
   |<--------------------------------------------------------------|
-  | -----------------------------------\                          |
-  |-| DNSKEY+NS matches RRSIG, use NS  |                          |
-  | |----------------------------------|                          |
-  | -------------------------------\                              |
-  |-| both DNR ADNs are authorized |                              |
-  | |------------------------------|                              |
+  | -------------------------------------\                        |
+  |-| DNSKEY+TXT matches RRSIG, use TXT  |                        |
+  | |------------------------------------|                        |
+  | --------------------------------\                             |
+  |-| dns.example.net is authorized |                             |
+  | |-------------------------------|                             |
   | ----------------------\                                       |
   |-| finished validation |                                       |
   | |---------------------|                                       |
@@ -547,7 +584,7 @@
         In this configuration, the message flow is similar to <xref
         target="internal-only"/>, except that queries for hosts not within the
         subdomain (e.g., <tt>www.example.com</tt>) are sent to the
-        external resolver rather than resolver for internal.example.com.</t>
+        external resolver rather than the resolver for internal.example.com.</t>
         <t>As in <xref target="internal-only"/>, the internal DNS
         server will need a certificate signed by a CA trusted by the
         client.</t>
@@ -564,10 +601,6 @@
     </section>
     <section anchor="Security">
       <name>Security Considerations</name>
-      <t>This specification does not alter DNSSEC validation behaviour. To
-      ensure compatibility with validating clients, network operators <bcp14>MUST</bcp14>
-      ensure that names under the split-horizon are correctly signed or place
-      them in an unsigned zone.</t>
       <t>If an internal zone name (e.g., <tt>internal.example.com</tt>) is used with
       this specification and a public certificate is obtained
       for validation, that internal zone name will exist in Certificate Transparency
@@ -584,10 +617,17 @@
       However, security by obscurity may not maintain or increase the security of the
       internal domain names, as they may be leaked in various other ways
       (e.g., browser reload).</t>
+      <t>The Authentication Domain Names of authorized local encrypted resolvers are
+      revealed in the Owner Names of Verification Records.  This makes it easier for
+      domain owners to understand which resolvers they are currently authorizing to
+      implement Split DNS, but it could create a confidentiality problem if the
+      local encrypted resolver's name is inside a secret subdomain. To avoid leakage,
+      local resolvers should be given a name that does not reveal any sensitive
+      information (perhaps in addition to the more sensitive name).</t>
     </section>
     <section anchor="IANA">
       <name>IANA Considerations</name>
-      <t>This document has no IANA actions.</t>
+      <t>TODO: New DHCP Auth Algorithm, PvD key, and underscore registry name.</t>
     </section>
     <section>
       <name>Acknowledgements</name>
@@ -603,12 +643,15 @@
       <references>
         <name>Normative References</name>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3118.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5155.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8174.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8801.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6762.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6698.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4035.xml"/>
         <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-add-ddr.xml"/>
+        <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-dnsop-domain-verification-techniques.xml"/>
         <reference anchor="IANA-SUDN"
                    target="https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml">
           <front>

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -28,7 +28,7 @@
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="std" docName="draft-ietf-add-split-horizon-authority-latest" ipr="trust200902" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3" consensus="true">
   <front>
     <title abbrev="Establishing Local DNS Authority">Establishing Local DNS
-    Authority in Split-Horizon Environments</title>
+    Authority in Validated Split-Horizon Environments</title>
     <seriesInfo name="Internet-Draft" value="draft-ietf-add-split-horizon-authority-latest"/>
     <author fullname="Tirumaleswar Reddy" initials="T." surname="Reddy">
       <organization>Nokia</organization>
@@ -66,7 +66,7 @@
     <author fullname="Benjamin Schwartz" initials="B." surname="Schwartz">
       <organization abbrev="Google">Google LLC</organization>
       <address>
-        <email>bemasc@google.com</email>
+        <email>ietf@bemasc.net</email>
       </address>
     </author>
     <date/>
@@ -139,7 +139,8 @@
       domain to a client (<xref target="establishing"/>). Clients can
       use this protocol to confirm that a local domain hint was authorized by
       the domain (<xref target="validating"/>), which might influence
-      its processing of that hint.</t>
+      its processing of that hint.  This process requires cooperation between
+      the local DNS zone and the public zone.</t>
       <t>This specification relies on securely identified local DNS servers,
       and checks each local domain hint against a globally valid parent zone.
       Use of this specification is therefore

--- a/token.sh
+++ b/token.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set +e
+
+readonly SALT="example salt bytes (should be random)"
+readonly NAME1="\x07payroll\0"
+readonly NAME2="\x06secret\x07project\0"
+readonly HASH_OUTPUT="$(echo "${NAME1}${NAME2}${SALT}" | sha1sum -)"
+readonly HASH_OUTPUT_ARRAY=($HASH_OUTPUT)
+readonly HASH_HEX="${HASH_OUTPUT_ARRAY[0]}"
+readonly HASH="$(echo "${HASH_HEX}" | tr [:lower:] [:upper:] | basenc --base16 -d -)"
+readonly HASH_BASE64="$(echo "${HASH}" | basenc --base64url -)"
+
+echo "${HASH_BASE64}"

--- a/token.sh
+++ b/token.sh
@@ -3,9 +3,11 @@
 set +e
 
 readonly SALT="example salt bytes (should be random)"
+declare -ir SALT_LENGTH=$(expr length "${SALT}")
+readonly SALT_LENGTH_BYTE="$(printf "\x$(printf %x "${SALT_LENGTH}")")"
 readonly NAME1="\x07payroll\0"
 readonly NAME2="\x06secret\x07project\0"
-readonly HASH_OUTPUT="$(echo "${NAME1}${NAME2}${SALT}" | sha1sum -)"
+readonly HASH_OUTPUT="$(echo "${SALT_LENGTH_BYTE}${SALT}${NAME1}${NAME2}" | shasum -a 384 -)"
 readonly HASH_OUTPUT_ARRAY=($HASH_OUTPUT)
 readonly HASH_HEX="${HASH_OUTPUT_ARRAY[0]}"
 readonly HASH="$(echo "${HASH_HEX}" | tr [:lower:] [:upper:] | basenc --base16 -d -)"


### PR DESCRIPTION
Based on recent mailing list discussions in ADD, this variant of Validated Split Horizon draws an explicit distinction between local encrypted resolvers and typical nameservers.  The local encrypted resolvers are authorized by publishing records under a special prefix, using hashes to conceal any local-only subdomains.

This version offers stronger confidentiality and supports a wider variety of zone structures, at the cost of considerably more complexity.