### PR TITLE
Proofread/nits

### DIFF
--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -94,8 +94,8 @@
       implementation can apply: (1) answer from a local database, (2) query
       the relevant authorities and their parents, or (3) ask a server to query
       those authorities and return the final answer. Implementations that use
-      these behaviors are called "authoritative nameservers", "full
-      resolvers", and "forwarders" (or "stub resolvers"). However, an
+      these behaviors are called "authoritative nameservers", "full/recursive 
+      resolvers", and "forwarders" (or "stub resolvers") respectively. However, an
       implementation can also implement a mixture of these behaviors,
       depending on a local policy, for each query. We term such an
       implementation a "hybrid resolver".</t>
@@ -159,7 +159,7 @@
       used throughout the document:</t>
       <dl>
         <dt>Encrypted DNS</dt><dd>A DNS protocol that provides an encrypted
-          channel between a DNS client and server (e.g., DoT, DoH, or DoQ).</dd>
+          channel between a DNS client and server (e.g., DNS over TLS (DoT)| HTTPS (DoH) | QUIC (DoQ)).</dd>
         <dt>Split-Horizon DNS</dt><dd>The DNS service provided by a resolver
           that also acts as an authoritative server for some names, providing
           resolution results that are meaningfully different from those in the
@@ -517,7 +517,7 @@ deeper.subdomain.parent.example. IN AAAA 2001:db8::18
           claims of DNS authority using an external resolver.</t>
           <ul empty="true">
             <li><strong>Steps 1-2</strong>: The client uses an encrypted DNS
-              connection to an external resolver (e.g., 1.1.1.1) to issue TXT
+              connection to an external resolver to issue TXT
               queries for the Verification Records. The TXT lookup returns
               a token that matches the claim.</li>
             <li><strong>Step 3</strong>: The client has validated that

--- a/draft-ietf-add-split-horizon-authority.xml
+++ b/draft-ietf-add-split-horizon-authority.xml
@@ -94,7 +94,7 @@
       implementation can apply: (1) answer from a local database, (2) query
       the relevant authorities and their parents, or (3) ask a server to query
       those authorities and return the final answer. Implementations that use
-      these behaviors are called "authoritative nameservers", "full/recursive 
+      these behaviors are called "authoritative nameservers", "full/recursive
       resolvers", and "forwarders" (or "stub resolvers") respectively. However, an
       implementation can also implement a mixture of these behaviors,
       depending on a local policy, for each query. We term such an
@@ -158,9 +158,10 @@
       target="RFC8499"/>, e.g. "Global DNS".  The following additional terms are
       used throughout the document:</t>
       <dl>
-        <dt>Encrypted DNS</dt><dd>A DNS protocol that provides an encrypted
-          channel between a DNS client and server (e.g., DNS over TLS (DoT)| HTTPS (DoH) | QUIC (DoQ)).</dd>
-        <dt>Split-Horizon DNS</dt><dd>The DNS service provided by a resolver
+        <dt>Encrypted DNS</dt><dd>A DNS protocol that provides an
+        encrypted channel between a DNS client and server (e.g., DNS
+        over TLS (DoT), HTTPS (DoH), QUIC (DoQ)).</dd>
+          <dt>Split-Horizon DNS</dt><dd>The DNS service provided by a resolver
           that also acts as an authoritative server for some names, providing
           resolution results that are meaningfully different from those in the
           Global DNS. (See "Split DNS" in <relref section="6"
@@ -267,9 +268,9 @@
         <t>To approve this claim, the zone operator would publish the following record
 	(using <xref target="RFC8792"/> line-wrapping):</t>
         <sourcecode type="dns-rr">
-  resolver17.parent.example._splitdns-challenge.parent.example. IN TXT \
-  "token=6rQ7oOZqdg8qQFRqtxpEhK97mNkgFwzNKTmNOtlxspBscZqUwFZZJDDD- \
-  Djetw2MCg"
+  resolver17.parent.example._splitdns-challenge.parent.example. \
+  IN TXT "token=6rQ7oOZqdg8qQFRqtxpEhK97mNkgFwzNKTmNOtlxspBscZq\
+  UwFZZJDDD-Djetw2MCg"
 </sourcecode>
       </section>
       <section>


### PR DESCRIPTION
line 97 "full resolver" -> "full/recursive resolver" (since "recursive resolver" is used line 111) line 98 grammar fix -> added "respectively" at the end of the sentence. line 162 expanded "Dot DoH DoQ" in the terminology line 520 removed "(e.g. 1.1.1.1)" as that's a specific live service, and also not guaranteed to always host a DNS resolver. RFC7322 #3.3 does not provide guidance on example IP addresses - only example domain names...but instead of replacing 1.1.1.1 with one of the IPv4 addresses reserved for documentation (RFC5737) I'd just remove the example.